### PR TITLE
feat: 去掉APISchema中索引签名影响,RequestPath类型更明确

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,4 +35,4 @@ const api = createRequestClient<TestAPISchema>({
 });
 
 api.getUser({ id: 1 }).then(res => console.log(res.data.name));
-api.createUser({ name: 'xx', avatar: 1 }).then(res => console.log(res.data.xxx));
+api.createUser({ name: 'xx', avatar: "1" }).then(res => console.log(res.data.xxx));

--- a/request.ts
+++ b/request.ts
@@ -29,7 +29,7 @@ function attachAPI<T extends APISchema>(
         // 配置为一个对象
         if (typeof apiConfig === 'object') {
             const { path, ...rest } = apiConfig as RequestOptions;
-            apiPath = path;
+            apiPath = path as RequestPath;
             apiOptions = rest;
         }
         hostApi[apiName] = (params, options) => {

--- a/type.ts
+++ b/type.ts
@@ -1,6 +1,12 @@
 import { AxiosRequestHeaders, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
+
+/** 去除可索引签名 */
+type RemoveIndexSignature<Obj extends Record<string, any>> = {
+    [Key in keyof Obj as Key extends `${infer Str}` ? Str : never]: Obj[Key];
+};
+
 // 路径配置
-export type RequestPath = string;
+export type RequestPath = `${Uppercase<RequestOptions['method']>} ${string}`;
 
 // 选项配置
 export type RequestOptions = {
@@ -31,11 +37,14 @@ export type CreateRequestConfig<T extends APISchema> = {
     headerHandlers?: Array<HeaderHandler>;
     errorHandler?: RequestErrorHandler;
     apis: {
-        [K in keyof T]: APIConfig;
+        [K in keyof RemoveIndexSignature<T>]: APIConfig;
     };
 };
 
 // 创建请求客户端的类型约束
 export type CreateRequestClient<T extends APISchema> = {
-    [K in keyof T]: RequestFunction<T[K]['request'], AxiosResponse<T[K]['response']>>;
+    [K in keyof RemoveIndexSignature<T>]: RequestFunction<
+        RemoveIndexSignature<T>[K]['request'],
+        AxiosResponse<RemoveIndexSignature<T>[K]['response']>
+    >;
 };


### PR DESCRIPTION
1. 在APISchema类型中的索引签名`[x; string]: any;`会影响类型约束，使用`RemoveIndexSignature<T>`高级类型去除该影响。
2. 将 RequestPath类型 从string 换为更加明确的`${Uppercase<RequestOptions['method']>} ${string}`。